### PR TITLE
fix: mesh コピー名を PID で一意化し並列プロセス競合を解消

### DIFF
--- a/src/mjcf/urdf_converter.cpp
+++ b/src/mjcf/urdf_converter.cpp
@@ -13,6 +13,11 @@
 #include <set>
 #include <sstream>
 #include <unordered_map>
+#ifndef _WIN32
+#include <unistd.h>
+#else
+#include <process.h>
+#endif
 #if __has_include(<tinyxml2/tinyxml2.h>)
 #include <tinyxml2/tinyxml2.h>
 #else
@@ -908,7 +913,12 @@ std::string UrdfConverter::generate_hash_filename(const std::string& original_pa
     hash_str = hash_str.substr(0, 5);
   }
   std::string filename = path.filename().string();
-  return hash_str + "_" + filename;
+#ifndef _WIN32
+  const long pid = static_cast<long>(getpid());
+#else
+  const long pid = static_cast<long>(_getpid());
+#endif
+  return hash_str + "_" + std::to_string(pid) + "_" + filename;
 }
 
 bool UrdfConverter::copy_mesh_file(const std::string& source_path, const std::string& dest_path) {


### PR DESCRIPTION
## 概要

`UrdfConverter::generate_hash_filename()` は source mesh の親ディレクトリのハッシュ + basename を返すため、同一 mesh を読む複数プロセスで同名になる。`copy_meshes=true` のとき、この名前で共有ディレクトリ（cwd 等）へ `copy_file` するので、同一作業ディレクトリから並列実行すると複数プロセスが同名ファイルを奪い合い、**書き込み途中（empty/truncated）のファイルを別プロセスが読んでモデルが壊れる**（`STL file is empty` / `wrong size; perhaps this is an ASCII file?` 等）。`mj_loadXML` 側の mutex 等ではプロセス間競合は防げない。

## 変更内容

`generate_hash_filename()` の戻り値に **PID** を混ぜて一意化する: `<hash>_<pid>_<basename>`。

- コピー先（`dest_mesh_path`）と MJCF 参照（`final_mesh_path`）は共にこの戻り値を使うため整合する。
- `getpid()` 用に `<unistd.h>` / `<process.h>`(Win) を追加。

## 補足

単一プロセス運用では従来どおり動作（ファイル名にプロセス固有の suffix が付くのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)